### PR TITLE
fix(vue): update vue version

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -60,10 +60,7 @@
     "rollup": "^4.20.0",
     "typescript": "^5.4.5",
     "vite": "^5.4.0",
-    "vue": "~3.3.9"
-  },
-  "peerDependencies": {
-    "vue": ">=3.3.9"
+    "vue": "~3.2.47"
   },
   "vetur": {
     "tags": "dist/vetur/tags.json",


### PR DESCRIPTION
something change between vue 3.2 and 3.3 that break the build

fixes: #30

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Project with poppy vue in it that use element with attr class cant build

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Project can build

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/CheeseGrinder/poppy-ui/blob/main/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->