### PR TITLE
fix(core): apply correct color on disabled button

### DIFF
--- a/packages/core/src/components/button/button.scss
+++ b/packages/core/src/components/button/button.scss
@@ -225,9 +225,9 @@
 :host([disabled]) {
   cursor: not-allowed;
 
-  > button:disabled {
+  button {
     --background: #{get-color("neutral.base", 0.2)};
-    --color: #{get-color("base.content", 0.2)};
+    color: #{get-color("base.content", 0.2)};
 
     pointer-events: none;
   }


### PR DESCRIPTION
the `--color` was not used, force color with the property

fixes: #35

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
The diasbled button does not have the correct color

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- correct color applied

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/CheeseGrinder/poppy-ui/blob/main/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->