### PR TITLE
fix(core): apply correct cursor

### DIFF
--- a/packages/core/src/components/dropdown/dropdown.scss
+++ b/packages/core/src/components/dropdown/dropdown.scss
@@ -29,6 +29,8 @@
       display: inline-block;
       grid-row-start: 1;
       grid-column-start: 1;
+
+      cursor: pointer;
     }
 
     &-content {


### PR DESCRIPTION
set the cursor on trigger's dropdown to pointer

fixes: #37

---------

The cursor on trigger's dropdown must be a pointer to tell the user he can click


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
dropdown has no cursor

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Set the cursor to `pointer`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/CheeseGrinder/poppy-ui/blob/main/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->