### PR TITLE
fix(core): apply correct padding

### DIFF
--- a/packages/core/src/components/card-body/card-body.scss
+++ b/packages/core/src/components/card-body/card-body.scss
@@ -18,3 +18,7 @@
     flex-grow: 1;
   }
 }
+
+:host-context(pop-card[compact]) {
+  --padding: 16px;
+}

--- a/packages/core/src/components/card-body/tests/basic/index.html
+++ b/packages/core/src/components/card-body/tests/basic/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Input Basic | Poppy-ui</title>
+    <link rel="stylesheet" href="/build/poppy.css">
+    <script type="module" src="/build/poppy.esm.js"></script>
+    <script nomodule src="/build/poppy.js"></script>
+    <style>
+        main {
+            width: 100vw;
+            height: 100dvh;
+            display: flex;
+            flex-direction: column;
+            gap: 1rem;
+            padding: 1rem;
+
+            background-color: var(--base-100);
+        }
+        section {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            gap: .35rem;
+        }
+        pop-card {
+            background-color: var(--base-300);
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <section>
+            <h2>Card - basic</h2>
+            <pop-card>
+                <pop-card-body>
+                    content
+                </pop-card-body>
+            </pop-card>
+        </section>
+        <section>
+            <h2>Card - compact</h2>
+            <pop-card compact>
+                <pop-card-body>
+                    content
+                </pop-card-body>
+            </pop-card>
+        </section>
+    </main>
+</body>
+</html>

--- a/packages/core/src/components/card/card.scss
+++ b/packages/core/src/components/card/card.scss
@@ -21,9 +21,3 @@
   background-color: var(--background);
   color: var(--color);
 }
-
-:host([compact]) {
-  :where(pop-card-body) {
-    --padding: 16px;
-  }
-}


### PR DESCRIPTION
move css to card-body, can not work if multiple card are nested

fixes: #36

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
card body does not have correct padding when compact property are set to true

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- apply compact css on `card-body`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/CheeseGrinder/poppy-ui/blob/main/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->