### PR TITLE
fix(input): input can be selected by type

### DIFF
--- a/packages/core/api.txt
+++ b/packages/core/api.txt
@@ -177,7 +177,7 @@ pop-input,prop,required,boolean,undefined,false,true
 pop-input,prop,size,"lg" | "md" | "sm" | "xs",undefined,false,true
 pop-input,prop,spellcheck,boolean,undefined,false,false
 pop-input,prop,step,string,undefined,false,false
-pop-input,prop,type,"date" | "datetime-local" | "email" | "month" | "number" | "password" | "search" | "tel" | "text" | "time" | "url" | "week",'text',false,false
+pop-input,prop,type,"date" | "datetime-local" | "email" | "month" | "number" | "password" | "search" | "tel" | "text" | "time" | "url" | "week",'text',false,true
 pop-input,prop,value,number | string,'',false,false
 pop-input,method,setFocus,setFocus() => Promise<void>
 pop-input,event,popBlur,void,true

--- a/packages/core/src/components/input/input.tsx
+++ b/packages/core/src/components/input/input.tsx
@@ -56,7 +56,7 @@ export class Input implements ComponentInterface {
   /**
    * The type of control to display. The default type is text.
    */
-  @Prop({ mutable: true }) type: InputType = 'text';
+  @Prop({ reflect: true, mutable: true }) type: InputType = 'text';
 
   /**
    * Instructional text that shows before the input has a value.
@@ -444,7 +444,7 @@ export class Input implements ComponentInterface {
         >
           <slot name="start" />
           <input
-            part="native"
+            part={`native ${this.type}`}
             id={inputId}
             name={this.name}
             type={this.type}


### PR DESCRIPTION
reflect `type` on host
add type on part

fixes: #40

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Input cant be selected depending on his type

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- reflect `type` on host
- add part depending on the type


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/CheeseGrinder/poppy-ui/blob/main/CONTRIBUTING.md#footer for more information.
-->


## Other information

```css
pop-input[type=password] {
 // ...
}
pop-input::part(password) {
 // ...
}
```


<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->